### PR TITLE
fixes #2 regarding compile

### DIFF
--- a/optparse.h
+++ b/optparse.h
@@ -1163,6 +1163,8 @@ namespace optparse
     class OptionParserExcept : public OptionParser
     {
     public:
+        OptionParserExcept() {}
+        OptionParserExcept(const OptionParser & parser) : OptionParser(parser) { }
         virtual void exit(int code) const
         {
             throw code;

--- a/test2.cpp
+++ b/test2.cpp
@@ -9,8 +9,7 @@ int main(int argc, char *argv[])
         "This is free software: you are free to change and redistribute it.\n"
         "There is NO WARRANTY, to the extent permitted by law.";
 
-    optparse::OptionParserExcept parser;
-    parser.version(version)
+    optparse::OptionParserExcept parser = optparse::OptionParserExcept().version(version)
           .description("Description")
           .epilog("Epilog");
 


### PR DESCRIPTION
when using shortened code in test2.cpp:

```C++
optparse::OptionParserExcept parser = optparse::OptionParserExcept().version(version)
           .description("Description")
           .epilog("Epilog");
```

The compiler errors with:

> error: conversion from 'optparse::OptionParser' to non-scalar type 'optparse::OptionParserExcept' requested

That's because `optparse::OptionParserExcept` doesn't define a copy constructor
of the Base class. Defining this, removes the error and allows it function as
intended.